### PR TITLE
Add `replaceCurrentType` to the parser

### DIFF
--- a/src/parser/Parser.h
+++ b/src/parser/Parser.h
@@ -161,6 +161,13 @@ private:
    */
   Syntax::Expression::Base* buildOperatorTree(std::vector<Syntax::Expression::Base*>& exprs);
 
+  /**
+   * @brief Replaces the type of the current token with another
+   */
+  void replaceCurrentType(TokenType new_type) {
+    m_current.type = new_type;
+  }
+
 private:
   // Parsing functions
 


### PR DESCRIPTION
Add a method called `replaceCurrentType` to the parser, which allows changing of the current token type.